### PR TITLE
Fix tracking link

### DIFF
--- a/map/embed.html
+++ b/map/embed.html
@@ -52,7 +52,6 @@
     }
 
     .labelInner {
-        padding: 3px 0px;
         font-family: Helvetica, sans-serif;
         font-size: 16px;
         color: white;
@@ -104,21 +103,6 @@
 
 	  ga('create', 'UA-47035811-1', 'auto');
 	  ga('send', 'pageview');
-	</script>
-	<script>
-	/**
-	* Function that tracks a click on an outbound link in Google Analytics.
-	* This function takes a valid URL string as an argument, and uses that URL string
-	* as the event label. Setting the transport method to 'beacon' lets the hit be sent
-	* using 'navigator.sendBeacon' in browser that support it.
-	*/
-	var trackOutboundLink = function(url, post_name, editor) {
-       // ga('send', 'event', [eventCategory], [eventAction], [eventLabel], [eventValue], [fieldsObject]);
-	   ga('send', 'event', 'outbound', post_name, url, {
-		 'transport': 'beacon',
-		 'hitCallback': function(){document.location = url;}
-	   });
-	}
 	</script>
 
     <style>

--- a/map/index.html
+++ b/map/index.html
@@ -52,7 +52,6 @@
     }
 
     .labelInner {
-        padding: 3px 0px;
         font-family: Helvetica, sans-serif;
         font-size: 16px;
         color: white;
@@ -115,21 +114,6 @@
 
 	  ga('create', 'UA-47035811-1', 'auto');
 	  ga('send', 'pageview');
-	</script>
-	<script>
-	/**
-	* Function that tracks a click on an outbound link in Google Analytics.
-	* This function takes a valid URL string as an argument, and uses that URL string
-	* as the event label. Setting the transport method to 'beacon' lets the hit be sent
-	* using 'navigator.sendBeacon' in browser that support it.
-	*/
-	var trackOutboundLink = function(url, post_name, editor) {
-       // ga('send', 'event', [eventCategory], [eventAction], [eventLabel], [eventValue], [fieldsObject]);
-	   ga('send', 'event', 'outbound', post_name, url, {
-		 'transport': 'beacon',
-		 'hitCallback': function(){document.location = url;}
-	   });
-	}
 	</script>
 
     <style>

--- a/map/main.js
+++ b/map/main.js
@@ -128,9 +128,9 @@ map = (function () {
                 {
 	                popup.style.visibility = 'visible';
 	            }
-                popup.innerHTML = '<span class="labelInner">' + 'You found a building that needs help!' + '</span><br>';
-                popup.innerHTML += '<span class="labelInner">' + '<a target="_blank" href="' + url + '" onclick="trackOutboundLink("' + url + '", editing_residential_buildings, iD); return false;">Edit with iD ➹</a>' + '</span><br>';
-                popup.innerHTML += '<span class="labelInner">' + '<a target="_blank" href="' + josmUrl + '" onclick="trackOutboundLink("' + josmUrl + '", editing_residential_buildings, JOSM); return false;">Edit with JOSM ➹</a>' + '</span><br>';
+                popup.innerHTML = '<div class="labelInner">' + 'You found a building that needs help!' + '</div>';
+                popup.appendChild(createEditLinkElement(url, 'iD', 'Edit with iD ➹'));
+                popup.appendChild(createEditLinkElement(josmUrl, 'JOSM', 'Edit with JOSM ➹'));
             });
         });
 
@@ -138,6 +138,37 @@ map = (function () {
             info.style.visibility = 'hidden';
             popup.style.visibility = 'hidden';
         });
+    }
+
+    function createEditLinkElement (url, type, label) {
+        var el = document.createElement('div');
+        var anchor = document.createElement('a');
+        el.className = 'labelInner';
+        anchor.href = url;
+        anchor.target = '_blank';
+        anchor.textContent = label;
+        anchor.addEventListener('click', function (event) {
+            trackOutboundLink(url, 'editing_residential_buildings', type);
+        }, false);
+        el.appendChild(anchor);
+        return el;
+    }
+
+    /**
+    * Function that tracks a click on an outbound link in Google Analytics.
+    * This function takes a valid URL string as an argument, and uses that URL string
+    * as the event label. Setting the transport method to 'beacon' lets the hit be sent
+    * using 'navigator.sendBeacon' in browser that support it.
+    */
+    function trackOutboundLink (url, post_name, editor) {
+       // ga('send', 'event', [eventCategory], [eventAction], [eventLabel], [eventValue], [fieldsObject]);
+       ga('send', 'event', 'outbound', post_name, url, {
+         'transport': 'beacon',
+         // If opening a link in the current window, this opens the url AFTER
+         // registering the hit with Analytics. Disabled because here want the
+         // link to open in a new window, so this hit can occur in the current tab.
+         //'hitCallback': function(){document.location = url;}
+       });
     }
 
 	function long2tile(lon,zoom) { return (Math.floor((lon+180)/360*Math.pow(2,zoom))); }


### PR DESCRIPTION
This PR fixes previous issues where tracking outbound links via Google Analytics was not working.
- Previously, inline Javascript tended to break because of nested strings that were not properly escaped. The main fix here is to change this behavior by not using inline Javascript. Now, anchor elements are constructed with event listeners that handle the click event. These anchor elements are appended to the popup.
- This is easier to do when the elements that are constructed are `<div>`s. `<span>`s required creating two elements: the `<span>` and a following `<br>`. This also simplifies the stylesheet somewhat.
- Finally I fixed an issue arising from `trackOutboundLink()` where it would open the url in both the current tab (via the `hitCallback` option) AND a new tab (via the anchor tag's `target`). While doing this, I also moved the function inside of `main.js` so that it did not need to appear in two places.
